### PR TITLE
Add timeout for liveview getting mounting

### DIFF
--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -42,8 +42,6 @@ async fn root(embed_liveview: EmbedLiveView) -> impl IntoResponse {
             <body>
                 { embed_liveview.embed(counter) }
 
-                <div id="thing">"The thing is here!"</div>
-
                 <script>
                     r#"
                         const liveView = new LiveView({ host: 'localhost', port: 4000 })


### PR DESCRIPTION
Otherwise the liveview task would get stuck if it never got mounted onto the websocket.