### PR TITLE
Extend character support for attributes

### DIFF
--- a/axum-live-view/src/html/tests.rs
+++ b/axum-live-view/src/html/tests.rs
@@ -127,6 +127,17 @@ fn attribute_with_dash() {
 }
 
 #[test]
+fn attribute_with_all_valid_characters() {
+    let view: Html<()> = html! {
+        <div class="col-md" @on:click.test-one_2="test">"foo"</div>
+    };
+    assert_eq!(
+        view.render(),
+        "<div class=col-md @on:click.test-one_2=test>foo</div>"
+    );
+}
+
+#[test]
 fn interpolate_class() {
     let size = 8;
     let view: Html<String> = html! {


### PR DESCRIPTION
Adds rudimentary support for additional attribute characters. This is mostly to accommodate alpine.js.

I'm not sure if doing it this way, or throwing it into a Syn step call was better. I specifically wanted to minimise the changes.