### PR TITLE
Update axum to 0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.idea
+.DS_Store
+
 /target
 node_modules
 dist

--- a/axum-live-view-macros/src/lib.rs
+++ b/axum-live-view-macros/src/lib.rs
@@ -37,7 +37,7 @@
     missing_debug_implementations,
     missing_docs
 )]
-#![deny(unreachable_pub, private_in_public)]
+#![deny(unreachable_pub)]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/axum-live-view/Cargo.toml
+++ b/axum-live-view/Cargo.toml
@@ -18,11 +18,12 @@ precompiled-js = []
 anyhow = "1.0"
 async-stream = "0.3"
 async-trait = "0.1"
-axum = { version = "0.6.0", features = ["ws"] }
+axum = { version = "0.7", features = ["ws", "macros",] }
+axum-macros = "0.4.1"
 axum-live-view-macros = { path = "../axum-live-view-macros", version = "0.1" }
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
-http = "0.2"
+http = "1.1"
 percent-encoding = "2.1"
 pin-project-lite = "0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/axum-live-view/Cargo.toml
+++ b/axum-live-view/Cargo.toml
@@ -18,7 +18,7 @@ precompiled-js = []
 anyhow = "1.0"
 async-stream = "0.3"
 async-trait = "0.1"
-axum = { version = "0.7", features = ["ws", "macros", ] }
+axum = { version = "0.7", features = ["ws", ] }
 axum-live-view-macros = { path = "../axum-live-view-macros", version = "0.1" }
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/axum-live-view/Cargo.toml
+++ b/axum-live-view/Cargo.toml
@@ -18,8 +18,7 @@ precompiled-js = []
 anyhow = "1.0"
 async-stream = "0.3"
 async-trait = "0.1"
-axum = { version = "0.7", features = ["ws", "macros",] }
-axum-macros = "0.4.1"
+axum = { version = "0.7", features = ["ws", "macros", ] }
 axum-live-view-macros = { path = "../axum-live-view-macros", version = "0.1" }
 bytes = "1.0"
 futures-util = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/axum-live-view/src/event_data.rs
+++ b/axum-live-view/src/event_data.rs
@@ -1,6 +1,7 @@
 //! Data associated with events from the client such as click or form events.
 
 mod inner {
+    #![allow(missing_docs)]
     use crate::life_cycle::{self, EventMessageFromSocketData};
     use serde::{de::DeserializeOwned, Serialize};
     use std::fmt;
@@ -13,7 +14,7 @@ mod inner {
     #[derive(Debug, Clone)]
     #[non_exhaustive]
     pub enum EventData {
-        /// An form event.
+        /// A form event.
         ///
         /// See [`Form`] for more details.
         Form(Form),
@@ -21,7 +22,7 @@ mod inner {
         ///
         /// See [`Input`] for more details.
         Input(Input),
-        /// An key event.
+        /// A key event.
         ///
         /// See [`Key`] for more details.
         Key(Key),
@@ -179,7 +180,7 @@ mod inner {
                     FormSerializationError(QuerySerializationErrorKind::Utf8Error(err))
                 })?;
 
-            let t = serde_qs::from_str(&*query).map_err(|err| {
+            let t = serde_qs::from_str(&query).map_err(|err| {
                 FormSerializationError(QuerySerializationErrorKind::Serialization(err))
             })?;
 
@@ -209,8 +210,8 @@ mod inner {
     impl std::error::Error for FormSerializationError {
         fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
             match &self.0 {
-                QuerySerializationErrorKind::Utf8Error(inner) => Some(&*inner),
-                QuerySerializationErrorKind::Serialization(inner) => Some(&*inner),
+                QuerySerializationErrorKind::Utf8Error(inner) => Some(inner),
+                QuerySerializationErrorKind::Serialization(inner) => Some(inner),
             }
         }
     }
@@ -221,6 +222,7 @@ mod inner {
     }
 
     impl FormBuilder {
+        #![allow(missing_docs)]
         pub fn new() -> Self {
             Self::default()
         }
@@ -252,6 +254,7 @@ mod inner {
     }
 
     impl Input {
+        #![allow(missing_docs)]
         pub fn as_bool(&self) -> Option<bool> {
             if let Self::Bool(inner) = self {
                 Some(*inner)
@@ -291,6 +294,7 @@ mod inner {
     }
 
     impl Key {
+        #![allow(missing_docs)]
         pub fn key(&self) -> &str {
             &self.key
         }

--- a/axum-live-view/src/html/diff.rs
+++ b/axum-live-view/src/html/diff.rs
@@ -82,8 +82,8 @@ impl<T> Html<T> {
             })
             .collect::<BTreeMap<usize, Option<DynamicFragmentDiff<T>>>>();
 
-        let new_fixed = (self.fixed != other.fixed).then(|| other.fixed);
-        let new_dynamic = (!dynamic.is_empty()).then(|| dynamic);
+        let new_fixed = (self.fixed != other.fixed).then_some(other.fixed);
+        let new_dynamic = (!dynamic.is_empty()).then_some(dynamic);
 
         match (new_fixed, new_dynamic) {
             (None, None) => None,

--- a/axum-live-view/src/html/render.rs
+++ b/axum-live-view/src/html/render.rs
@@ -30,7 +30,7 @@ where
                 let _ = render_to(html.fixed, &html.dynamic, out);
             }
             Some((_, DynamicFragment::String(s))) => {
-                out.push_str(&*s);
+                out.push_str(s);
             }
             Some((_, DynamicFragment::Message(msg))) => {
                 let encoded_msg = serde_json::to_string(msg).unwrap();

--- a/axum-live-view/src/lib.rs
+++ b/axum-live-view/src/lib.rs
@@ -26,11 +26,9 @@
 //!         .route("/assets/live-view.js", axum_live_view::precompiled_js());
 //!
 //!     # async {
-//!     // ...that we run like any other axum app
-//!     axum::Server::bind(&"0.0.0.0:3000".parse().unwrap())
-//!         .serve(app.into_make_service())
-//!         .await
-//!         .unwrap();
+//!       // ...that we run like any other axum app
+//!       let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+//!       axum::serve(listener, app).await.unwrap();
 //!     # };
 //! }
 //!
@@ -336,9 +334,9 @@ pub const PRECOMPILED_JS: &str = include_str!("../../assets-precompiled/axum_liv
 #[cfg(feature = "precompiled-js")]
 #[cfg_attr(docsrs, doc(cfg(feature = "precompiled-js")))]
 #[allow(clippy::declare_interior_mutable_const)]
-pub fn precompiled_js<S, B>() -> axum::routing::MethodRouter<S, B>
+pub fn precompiled_js<S>() -> axum::routing::MethodRouter<S>
 where
-    B: axum::body::HttpBody + Send + 'static,
+    // B: axum::body::HttpBody + Send + 'static,
     S: Clone + Send + Sync + 'static,
 {
     use axum::{

--- a/axum-live-view/src/lib.rs
+++ b/axum-live-view/src/lib.rs
@@ -255,7 +255,7 @@
     missing_debug_implementations,
     missing_docs
 )]
-#![deny(unreachable_pub, private_in_public)]
+#![deny(unreachable_pub)]
 #![allow(elided_lifetimes_in_paths, clippy::type_complexity)]
 #![forbid(unsafe_code)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/axum-live-view/src/life_cycle.rs
+++ b/axum-live-view/src/life_cycle.rs
@@ -180,7 +180,6 @@ where
                     handle,
                     reply_tx,
                 } => {
-                    // TODO(mathias): Clippy provides this suggestion - double check it
                     let _ = {
                         view.mount(uri, &headers, handle);
                         reply_tx.send(())

--- a/axum-live-view/src/life_cycle.rs
+++ b/axum-live-view/src/life_cycle.rs
@@ -180,7 +180,11 @@ where
                     handle,
                     reply_tx,
                 } => {
-                    let _ = reply_tx.send(view.mount(uri, &headers, handle));
+                    // TODO(mathias): Clippy provides this suggestion - double check it
+                    let _ = {
+                        view.mount(uri, &headers, handle);
+                        reply_tx.send(())
+                    };
                 }
                 ViewRequest::Render { reply_tx } => {
                     let _ = reply_tx
@@ -214,7 +218,7 @@ where
 
                     let new_markup = wrap_in_live_view_container(view.render());
                     let diff = markup.diff(&new_markup).map(|diff| {
-                        serde_json::to_value(&diff).expect("failed to serialize HTML diff")
+                        serde_json::to_value(diff).expect("failed to serialize HTML diff")
                     });
                     markup = new_markup;
 

--- a/axum-live-view/src/live_view/combine.rs
+++ b/axum-live-view/src/live_view/combine.rs
@@ -94,7 +94,7 @@ where
             handle.clone().with(Either1::T1),
         );
     }
-    fn update(mut self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
+    fn update(self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
         match msg {
             Either1::T1(msg) => {
                 let Self {
@@ -158,7 +158,7 @@ where
             handle.clone().with(Either2::T2),
         );
     }
-    fn update(mut self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
+    fn update(self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
         match msg {
             Either2::T1(msg) => {
                 let Self {
@@ -253,7 +253,7 @@ where
             handle.clone().with(Either3::T3),
         );
     }
-    fn update(mut self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
+    fn update(self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
         match msg {
             Either3::T1(msg) => {
                 let Self {
@@ -382,7 +382,7 @@ where
             handle.clone().with(Either4::T4),
         );
     }
-    fn update(mut self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
+    fn update(self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
         match msg {
             Either4::T1(msg) => {
                 let Self {
@@ -543,7 +543,7 @@ where
             handle.clone().with(Either5::T5),
         );
     }
-    fn update(mut self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
+    fn update(self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
         match msg {
             Either5::T1(msg) => {
                 let Self {
@@ -790,7 +790,7 @@ where
             handle.clone().with(Either6::T6),
         );
     }
-    fn update(mut self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
+    fn update(self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
         match msg {
             Either6::T1(msg) => {
                 let Self {
@@ -1099,7 +1099,7 @@ where
             handle.clone().with(Either7::T7),
         );
     }
-    fn update(mut self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
+    fn update(self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
         match msg {
             Either7::T1(msg) => {
                 let Self {
@@ -1459,7 +1459,7 @@ where
             handle.clone().with(Either8::T8),
         );
     }
-    fn update(mut self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
+    fn update(self, msg: Self::Message, data: Option<EventData>) -> Updated<Self> {
         match msg {
             Either8::T1(msg) => {
                 let Self {

--- a/axum-live-view/src/util/stream_ext.rs
+++ b/axum-live-view/src/util/stream_ext.rs
@@ -126,7 +126,7 @@ where
     T: Stream,
     U: Stream<Item = T::Item>,
 {
-    use Poll::*;
+    use Poll::{Pending, Ready};
 
     let mut done = true;
 

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.6.0-rc.5"
+axum = "0.7.4"
 axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.0", features = ["full"] }
@@ -14,4 +14,4 @@ serde = { version = "1.0", features = ["derive"] }
 tower = "0.4"
 serde_json = "1.0"
 futures-util = "0.3"
-tower-http = { version = "0.2", features = ["fs"] }
+tower-http = { version = "0.5.2", features = ["fs"] }

--- a/examples/chat/Cargo.toml
+++ b/examples/chat/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.7.4"
+axum = "0.7"
 axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.0", features = ["full"] }
@@ -14,4 +14,4 @@ serde = { version = "1.0", features = ["derive"] }
 tower = "0.4"
 serde_json = "1.0"
 futures-util = "0.3"
-tower-http = { version = "0.5.2", features = ["fs"] }
+tower-http = { version = "0.5", features = ["fs"] }

--- a/examples/clock/Cargo.toml
+++ b/examples/clock/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.6.0-rc.5"
+axum = "0.7.4"
 axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-tower-http = { version = "0.2", features = ["fs"] }
+tower-http = { version = "0.5.2", features = ["fs"] }
 time = { version = "0.3.5", features = ["local-offset", "formatting"] }

--- a/examples/clock/Cargo.toml
+++ b/examples/clock/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.7.4"
+axum = "0.7"
 axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -1,8 +1,8 @@
-use axum::{async_trait, response::IntoResponse, routing::get, Router};
+use axum::{response::IntoResponse, routing::get, Router};
+
 use axum_live_view::{
     event_data::EventData, html, live_view::Updated, Html, LiveView, LiveViewUpgrade,
 };
-use std::{convert::Infallible, net::SocketAddr};
 
 #[tokio::main]
 async fn main() {
@@ -12,11 +12,8 @@ async fn main() {
         .route("/", get(root))
         .route("/bundle.js", axum_live_view::precompiled_js());
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }
 
 async fn root(live: LiveViewUpgrade) -> impl IntoResponse {

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -5,10 +5,10 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.6.0-rc.5"
+axum = "0.7.4"
 axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }
-tower-http = { version = "0.2", features = ["fs"] }
+tower-http = { version = "0.5.2", features = ["fs"] }

--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.7.4"
+axum = "0.7"
 axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -1,23 +1,19 @@
 use axum::{response::IntoResponse, routing::get, Router};
+use serde::{Deserialize, Serialize};
+
 use axum_live_view::{
     event_data::EventData, html, live_view::Updated, Html, LiveView, LiveViewUpgrade,
 };
-use serde::{Deserialize, Serialize};
-use std::net::SocketAddr;
 
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
-
     let app = Router::new()
         .route("/", get(root))
         .route("/bundle.js", axum_live_view::precompiled_js());
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }
 
 async fn root(live: LiveViewUpgrade) -> impl IntoResponse {

--- a/examples/form/Cargo.toml
+++ b/examples/form/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.6.0-rc.5"
+axum = "0.7.4"
 axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde_json = "1.0"
-tower-http = { version = "0.2", features = ["fs"] }
+tower-http = { version = "0.5.2", features = ["fs"] }

--- a/examples/form/Cargo.toml
+++ b/examples/form/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.7.4"
+axum = "0.7"
 axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -262,6 +262,7 @@ impl FormView {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 #[serde(untagged)]
 enum ChangedInputValue {
     Select(String),

--- a/examples/form/src/main.rs
+++ b/examples/form/src/main.rs
@@ -1,9 +1,11 @@
+use std::collections::HashMap;
+
 use axum::{response::IntoResponse, routing::get, Router};
+use serde::{Deserialize, Serialize};
+
 use axum_live_view::{
     event_data::EventData, html, live_view::Updated, Html, LiveView, LiveViewUpgrade,
 };
-use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, net::SocketAddr};
 
 #[tokio::main]
 async fn main() {
@@ -13,11 +15,8 @@ async fn main() {
         .route("/", get(root))
         .route("/bundle.js", axum_live_view::precompiled_js());
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }
 
 async fn root(live: LiveViewUpgrade) -> impl IntoResponse {

--- a/examples/key-events/Cargo.toml
+++ b/examples/key-events/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.6.0-rc.5"
+axum = "0.7.4"
 axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 serde_json = "1.0"
-tower-http = { version = "0.2", features = ["fs"] }
+tower-http = { version = "0.5.2", features = ["fs"] }

--- a/examples/key-events/Cargo.toml
+++ b/examples/key-events/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2018"
 publish = false
 
 [dependencies]
-axum = "0.7.4"
+axum = "0.7"
 axum-live-view = { path = "../../axum-live-view", version = "0.1", features = ["precompiled-js"] }
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.0", features = ["full"] }

--- a/examples/key-events/src/main.rs
+++ b/examples/key-events/src/main.rs
@@ -1,9 +1,9 @@
-use axum::{async_trait, response::IntoResponse, routing::get, Router};
+use axum::{response::IntoResponse, routing::get, Router};
+use serde::{Deserialize, Serialize};
+
 use axum_live_view::{
     event_data::EventData, html, live_view::Updated, Html, LiveView, LiveViewUpgrade,
 };
-use serde::{Deserialize, Serialize};
-use std::{convert::Infallible, net::SocketAddr};
 
 #[tokio::main]
 async fn main() {
@@ -13,11 +13,8 @@ async fn main() {
         .route("/", get(root))
         .route("/bundle.js", axum_live_view::precompiled_js());
 
-    let addr = SocketAddr::from(([0, 0, 0, 0], 3000));
-    axum::Server::bind(&addr)
-        .serve(app.into_make_service())
-        .await
-        .unwrap();
+    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
+    axum::serve(listener, app).await.unwrap();
 }
 
 async fn root(live: LiveViewUpgrade) -> impl IntoResponse {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -66,7 +66,7 @@ fn ts_build(opt: TsBuild) -> Result {
     if check {
         cmd.arg("--noEmit");
     } else {
-        cmd.args(&["--build"]);
+        cmd.args(["--build"]);
     }
 
     run_cmd(cmd)?;
@@ -343,7 +343,7 @@ fn codegen() -> Result {
 
     let mut cmd = Command::new("cargo");
     cmd.current_dir(project_root());
-    cmd.args(&["fmt"]);
+    cmd.args(["fmt"]);
     cmd.status()?;
 
     Ok(())


### PR DESCRIPTION
Updating to `axum 0.7` and making small adjustments to the lib and examples to accommodate for the new version.

Sprinkling `#![allow(missing_docs)]` and `#[allow(dead_code)]` here and there to make clippy happy.
